### PR TITLE
filechooser: Add support for check/combo "choices"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(PROJECT_VERSION "0.0.1")
 project(xdg-desktop-portal-lxqt VERSION ${PROJECT_VERSION})
 
 set(QT_MIN_VERSION "5.15.0")
+set(LIBFMQT_MINIMUM_VERSION "1.0.0")
 set(KF5_MIN_VERSION "5.78")
 
 set(CMAKE_AUTOMOC on)
@@ -17,7 +18,8 @@ find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
     DBus
     Widgets
 )
-
+find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)  # seems to be required by fm-qt
+find_package(fm-qt ${LIBFMQT_MINIMUM_VERSION} REQUIRED)
 find_package(KF5WindowSystem ${KF5_MIN_VERSION} REQUIRED)
 
 add_subdirectory(data)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # xdg-desktop-portal-lxqt
 
 A backend implementation for [xdg-desktop-portal](http://github.com/flatpak/xdg-desktop-portal)
-that is using Qt/KF5.
+that is using Qt/KF5/libfm-qt.
 
 ## Building xdg-desktop-portal-lxqt
 
@@ -9,9 +9,11 @@ that is using Qt/KF5.
 - Build + Runtime
   - Qt 5
   - KDE Frameworks - KWindowSystem
+  - libfm-qt
 - Runtime only
+  - Qt 5
+  - KDE Frameworks - KWindowSystem
   - xdg-desktop-portal
-  - lxqt-qtplugin
   - libfm-qt
 
 ### Build instructions:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ target_link_libraries(xdg-desktop-portal-lxqt
     Qt::Core
     Qt::DBus
     Qt::Widgets
+    fm-qt
     KF5::WindowSystem
 )
 


### PR DESCRIPTION
Adding additional widget into QFileWidget is not possible, when the
platform-native file dialog is used. Therefore we need to use the
Fm::FileDialog directly.