### PR TITLE
filechooser: Use Fm:FileDialogHelper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
 
-set(PROJECT_VERSION "0.1.0")
+set(PROJECT_VERSION "0.2.0")
 
 project(xdg-desktop-portal-lxqt VERSION ${PROJECT_VERSION})
 
 set(QT_MIN_VERSION "5.15.0")
-set(LIBFMQT_MINIMUM_VERSION "1.0.0")
+set(LIBFMQT_MINIMUM_VERSION "1.0.1")
 set(KF5_MIN_VERSION "5.78")
 
 set(CMAKE_AUTOMOC on)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,13 @@
 set(SRCS
     utils.cpp
+    filedialoghelper.cpp
     filechooser.cpp
     desktopportal.cpp
     main.cpp
+)
+
+include_directories(
+    ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
 )
 
 add_executable(xdg-desktop-portal-lxqt ${SRCS})

--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -29,6 +29,7 @@
 
 #include "filechooser.h"
 #include "utils.h"
+#include "filedialoghelper.h"
 
 #include <QDBusArgument>
 #include <QDBusMetaType>
@@ -213,8 +214,8 @@ namespace LXQt
             optionsWidget.reset(CreateChoiceControls(optionList, checkboxes, comboboxes));
         }
 
-        QScopedPointer<Fm::FileDialog, QScopedPointerDeleteLater> fileDialog{new Fm::FileDialog{nullptr}};
-        Utils::setParentWindow(fileDialog.data(), parent_window);
+        auto fileDialog = FileDialogHelper::createFileDialogHelper();
+        Utils::setParentWindow(&fileDialog->dialog(), parent_window);
         fileDialog->setWindowTitle(title);
         fileDialog->setModal(modalDialog);
         fileDialog->setFileMode(directory ? QFileDialog::Directory : (multipleFiles ? QFileDialog::ExistingFiles : QFileDialog::ExistingFile));
@@ -235,12 +236,12 @@ namespace LXQt
         }
 
         if (optionsWidget) {
-            if (auto layout = fileDialog->layout()) {
+            if (auto layout = fileDialog->dialog().layout()) {
                 layout->addWidget(optionsWidget.get());
             }
         }
 
-        if (fileDialog->exec() == QDialog::Accepted) {
+        if (fileDialog->execResult() == QDialog::Accepted) {
             QStringList files;
             for (const auto & url : fileDialog->selectedFiles()) {
                 files << url.toDisplayString();
@@ -334,8 +335,8 @@ namespace LXQt
             optionsWidget.reset(CreateChoiceControls(optionList, checkboxes, comboboxes));
         }
 
-        QScopedPointer<Fm::FileDialog, QScopedPointerDeleteLater> fileDialog{new Fm::FileDialog{nullptr}};
-        Utils::setParentWindow(fileDialog.data(), parent_window);
+        auto fileDialog = FileDialogHelper::createFileDialogHelper();
+        Utils::setParentWindow(&fileDialog->dialog(), parent_window);
         fileDialog->setWindowTitle(title);
         fileDialog->setModal(modalDialog);
         fileDialog->setFileMode(QFileDialog::AnyFile);
@@ -376,12 +377,12 @@ namespace LXQt
         }
 
         if (optionsWidget) {
-            if (auto layout = fileDialog->layout()) {
+            if (auto layout = fileDialog->dialog().layout()) {
                 layout->addWidget(optionsWidget.get());
             }
         }
 
-        if (fileDialog->exec() == QDialog::Accepted) {
+        if (fileDialog->execResult() == QDialog::Accepted) {
             QStringList files;
             for (const auto & url : fileDialog->selectedFiles()) {
                 files << url.toDisplayString();

--- a/src/filedialoghelper.cpp
+++ b/src/filedialoghelper.cpp
@@ -1,0 +1,56 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt-project.org
+ *
+ * Copyright: 2022~ LXQt team
+ * Authors:
+ *   Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include "filedialoghelper.h"
+#include <libfm-qt/libfmqt.h>
+#include <QCoreApplication>
+#include <QWindow>
+
+namespace LXQt
+{
+    /*static*/ std::unique_ptr<FileDialogHelper> FileDialogHelper::createFileDialogHelper()
+    {
+        static std::unique_ptr<Fm::LibFmQt> libfmQtContext_;
+        if(!libfmQtContext_) {
+            // initialize libfm-qt only once
+            libfmQtContext_ = std::unique_ptr<Fm::LibFmQt>{new Fm::LibFmQt()};
+            // add translations
+            QCoreApplication::installTranslator(libfmQtContext_.get()->translator());
+        }
+        auto d = std::unique_ptr<FileDialogHelper>{new FileDialogHelper{}};
+        d->setOptions(QFileDialogOptions::create());
+        return d;
+    }
+
+    int FileDialogHelper::execResult()
+    {
+        show(dialog().windowFlags(), dialog().windowModality(), dialog().windowHandle() ? dialog().windowHandle()->transientParent() : nullptr);
+        Fm::FileDialogHelper::exec();
+        return dialog().result();
+    }
+
+}

--- a/src/filedialoghelper.h
+++ b/src/filedialoghelper.h
@@ -1,0 +1,60 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)LGPL2+
+ *
+ * LXQt - a lightweight, Qt based, desktop toolset
+ * https://lxqt-project.org
+ *
+ * Copyright: 2022~ LXQt team
+ * Authors:
+ *   Palo Kisa <palo.kisa@gmail.com>
+ *
+ * This program or library is free software; you can redistribute it
+ * and/or modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+
+ * You should have received a copy of the GNU Lesser General
+ * Public License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include <libfm-qt/filedialoghelper.h>
+#include <libfm-qt/filedialog.h>
+#include <memory>
+#include <QFileDialog>
+
+namespace Fm
+{
+    class FileDialog;
+}
+
+namespace LXQt
+{
+    class FileDialogHelper : public Fm::FileDialogHelper
+    {
+    public:
+        static std::unique_ptr<FileDialogHelper> createFileDialogHelper();
+
+    private:
+        FileDialogHelper() = default;
+
+    public:
+        inline Fm::FileDialog & dialog() { return Fm::FileDialogHelper::dialog(); }
+        inline void setFileMode(QFileDialog::FileMode mode) { options()->setFileMode(static_cast<QFileDialogOptions::FileMode>(mode)); }
+        inline void setWindowTitle(const QString & title) { options()->setWindowTitle(title); }
+        inline void setModal(bool modal) { dialog().setModal(modal); }
+        inline void setLabelText(QFileDialog::DialogLabel label, const QString &text) { options()->setLabelText(static_cast<QFileDialogOptions::DialogLabel>(label), text); };
+        inline void setMimeTypeFilters(const QStringList &filters) { options()->setMimeTypeFilters(filters); }
+        inline void setNameFilters(const QStringList &filters) { options()->setNameFilters(filters); }
+        inline void setAcceptMode(QFileDialog::AcceptMode mode) { options()->setAcceptMode(static_cast<QFileDialogOptions::AcceptMode>(mode)); }
+        int execResult();
+
+    };
+}


### PR DESCRIPTION
By usage of Fm::FileDialogHelper we will get the "native LXQt" feel, as
the helper is applying & saving preferences. This way apps using
xdg-portal will behave like the native Qt apps under LXQt.

This needs lxqt/libfm-qt#777

Closes #7 