### PR TITLE
Require exif

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ find_package(Qt5 ${QT_MIN_VERSION} CONFIG REQUIRED COMPONENTS
 find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)  # seems to be required by fm-qt
 find_package(fm-qt ${LIBFMQT_MINIMUM_VERSION} REQUIRED)
 find_package(KF5WindowSystem ${KF5_MIN_VERSION} REQUIRED)
+find_package(Exif REQUIRED)
 
 add_subdirectory(data)
 add_subdirectory(src)


### PR DESCRIPTION
I don't see where we use that in the code but without this I get:

```
[    4s] AutoMoc: Generating MOC compilation "SRC:/build/src/xdg-desktop-portal-lxqt_autogen/mocs_compilation.cpp"
[    4s] AutoGen: Writing the parse cache file "SRC:/build/src/CMakeFiles/xdg-desktop-portal-lxqt_autogen.dir/ParseCache.txt"
[    4s] AutoGen: Writing the settings file "SRC:/build/src/CMakeFiles/xdg-desktop-portal-lxqt_autogen.dir/AutogenUsed.txt"
[    4s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build'
[    4s] make[1]: Entering directory '/home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build'
[    4s] [ 12%] Built target xdg-desktop-portal-lxqt_autogen
[    4s] make[1]: Leaving directory '/home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build'
[    4s] /usr/bin/make  -f src/CMakeFiles/xdg-desktop-portal-lxqt.dir/build.make src/CMakeFiles/xdg-desktop-portal-lxqt.dir/depend
[    4s] make[2]: Entering directory '/home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build'
[    4s] cd /home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build && /usr/bin/cmake -E cmake_depends "Unix Makefiles" /home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0 /hom↪ e/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/src /home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build /home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build/sr↪ c /home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build/src/CMakeFiles/xdg-desktop-portal-lxqt.dir/DependInfo.cmake
[    4s] make[2]: Leaving directory '/home/abuild/rpmbuild/BUILD/xdg-desktop-portal-lxqt-0.2.0/build'
[    4s] /usr/bin/make  -f src/CMakeFiles/xdg-desktop-portal-lxqt.dir/build.make src/CMakeFiles/xdg-desktop-portal-lxqt.dir/build
[    4s] make[2]: *** No rule to make target '/usr/lib64/libexif.so', needed by 'src/xdg-desktop-portal-lxqt'.  Stop.
```