### PR TITLE
filechooser: Support current_folder with OpenFile

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -181,6 +181,7 @@ namespace LXQt
         bool directory = false;
         bool modalDialog = true;
         bool multipleFiles = false;
+        QUrl currentFolder;
         QStringList nameFilters;
         QStringList mimeTypeFilters;
         QString selectedMimeTypeFilter;
@@ -199,6 +200,10 @@ namespace LXQt
 
         if (options.contains(QStringLiteral("directory"))) {
             directory = options.value(QStringLiteral("directory")).toBool();
+        }
+
+        if (options.contains(QStringLiteral("current_folder"))) {
+            currentFolder = QUrl::fromLocalFile(options.value(QStringLiteral("current_folder")).toString());
         }
 
         ExtractFilters(options, nameFilters, mimeTypeFilters, allFilters, selectedMimeTypeFilter);
@@ -222,7 +227,9 @@ namespace LXQt
         if (!acceptLabel.isEmpty())
             fileDialog->setLabelText(QFileDialog::Accept, acceptLabel);
 
-        if (mLastVisitedDirs.count(parent_window) > 0) {
+        if (currentFolder.isValid()) {
+            fileDialog->setDirectory(currentFolder);
+        } else if (mLastVisitedDirs.count(parent_window) > 0) {
             fileDialog->setDirectory(mLastVisitedDirs[parent_window]);
         }
 


### PR DESCRIPTION
See https://github.com/flatpak/xdg-desktop-portal/issues/796. Works with xdg-desktop-portal 1.18 and newer, tested on Fedora 39.