### PR TITLE
filechooser: Convert mimetype filters to name filters

### DIFF
--- a/src/filechooser.h
+++ b/src/filechooser.h
@@ -96,9 +96,10 @@ namespace LXQt
 
         static void ExtractFilters(const QVariantMap &options,
                 QStringList &nameFilters,
-                QStringList &mimeTypeFilters,
                 QMap<QString, FilterList> &allFilters,
-                QString &selectedMimeTypeFilter);
+                QString &selectedNameFilter);
+
+        static QStringList NameFiltersForMimeType(const QString &mimeType);
 
     private:
         QMap<QString, QUrl> mLastVisitedDirs;

--- a/src/filedialoghelper.h
+++ b/src/filedialoghelper.h
@@ -51,7 +51,6 @@ namespace LXQt
         inline void setWindowTitle(const QString & title) { options()->setWindowTitle(title); }
         inline void setModal(bool modal) { dialog().setModal(modal); }
         inline void setLabelText(QFileDialog::DialogLabel label, const QString &text) { options()->setLabelText(static_cast<QFileDialogOptions::DialogLabel>(label), text); };
-        inline void setMimeTypeFilters(const QStringList &filters) { options()->setMimeTypeFilters(filters); }
         inline void setNameFilters(const QStringList &filters) { options()->setNameFilters(filters); }
         inline void setAcceptMode(QFileDialog::AcceptMode mode) { options()->setAcceptMode(static_cast<QFileDialogOptions::AcceptMode>(mode)); }
         int execResult();


### PR DESCRIPTION
Allows name filters and mimetype filters to be combined, as per the portal specification. The current implementation only allows one or the other per dialog, so if an application uses both, all the name filters are dropped.