### PR TITLE
service: Don't fork child process and simplify

### DIFF
--- a/data/org.freedesktop.impl.portal.desktop.lxqt.service.in
+++ b/data/org.freedesktop.impl.portal.desktop.lxqt.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.desktop.lxqt
-Exec=/bin/sh -c 'env QT_QPA_PLATFORMTHEME=lxqt @CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-lxqt'
+Exec=/bin/sh -c 'QT_QPA_PLATFORMTHEME=lxqt exec @CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-lxqt'


### PR DESCRIPTION
1. The "parent" running shell just waiting for the xdg-desktop-portal-lxqt process is superfluous.
2. POSIX sh spec already defines passing env variables by specifying assignment in front of command => we don't need to rely on (possibly missing) external env command.

Before:
UID          PID    PPID  C STIME TTY          TIME CMD
user        2226    1882  0 07:52 ?        00:00:00     /bin/sh -c env QT_QPA_PLATFORMTHEME=lxqt /usr/libexec/xdg-desktop-portal-lxqt
user        2227    2226  0 07:52 ?        00:00:00       /usr/libexec/xdg-desktop-portal-lxqt

After:
UID          PID    PPID  C STIME TTY          TIME CMD
user        7465    1882  9 09:37 ?        00:00:00     /usr/libexec/xdg-desktop-portal-lxqt