### PR TITLE
Use a native systemd service

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,7 +1,9 @@
 configure_file(org.freedesktop.impl.portal.desktop.lxqt.desktop.in org.freedesktop.impl.portal.desktop.lxqt.desktop @ONLY)
 configure_file(org.freedesktop.impl.portal.desktop.lxqt.service.in org.freedesktop.impl.portal.desktop.lxqt.service @ONLY)
+configure_file(xdg-desktop-portal-lxqt.service.in xdg-desktop-portal-lxqt.service @ONLY)
 
 install(FILES lxqt-portals.conf DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/xdg-desktop-portal")
 install(FILES lxqt.portal DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/xdg-desktop-portal/portals")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.impl.portal.desktop.lxqt.service DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/dbus-1/services")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.freedesktop.impl.portal.desktop.lxqt.desktop DESTINATION "${CMAKE_INSTALL_FULL_DATAROOTDIR}/applications")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/xdg-desktop-portal-lxqt.service DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/systemd/user")

--- a/data/org.freedesktop.impl.portal.desktop.lxqt.service.in
+++ b/data/org.freedesktop.impl.portal.desktop.lxqt.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.desktop.lxqt
 Exec=/bin/sh -c 'QT_QPA_PLATFORMTHEME=lxqt exec @CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-lxqt'
+SystemdService=xdg-desktop-portal-lxqt.service

--- a/data/xdg-desktop-portal-lxqt.service.in
+++ b/data/xdg-desktop-portal-lxqt.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Portal service (LXQT implementation)
+PartOf=graphical-session.target
+After=graphical-session.target
+
+[Service]
+Type=dbus
+Environment="QT_QPA_PLATFORMTHEME=lxqt"
+BusName=org.freedesktop.impl.portal.desktop.lxqt
+ExecStart=@CMAKE_INSTALL_FULL_LIBEXECDIR@/xdg-desktop-portal-lxqt


### PR DESCRIPTION
So far we've ran the portal executable from the service invoked by D-Bus, directly. This type of systemd service is profoundly limited, with Fedora (for example) [advising](https://fedoraproject.org/wiki/Packaging:Systemd#DBus_activation) that bus-activateable services should be used to start a "normal" systemd service. The examples in systemd.service.5 manual page [also suggest](https://man.archlinux.org/man/core/systemd/systemd.service.5.en#:~:text=Example%C2%A07.%C2%A0DBus-,services,-For%20services%20that) one should switch to doing this. How? The `SystemdService=` entry.

This is also in line with gtk's portal, our friends [use `SystemdService=`](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/main/data/org.freedesktop.impl.portal.desktop.gtk.service.in#L4C1-L4C15) too.

To provide a sense of what this does, this allows using `systemctl disable `and `systemctl enable` on the service, among other control features that the barebones dbus-activateable services don't have.

The environment variable (`QT_QPA_PLATFORMTHEME`) can now also be set using "Environment=", which is idiomatic, whereas previously it was set by calling `sh`. The bonus is that this allows user overrides (I was interested in customizing the  environment variable).