### PR TITLE
Make dialog modal only for the window

### DIFF
--- a/src/filechooser.cpp
+++ b/src/filechooser.cpp
@@ -238,7 +238,7 @@ namespace LXQt
         auto fileDialog = FileDialogHelper::createFileDialogHelper();
         Utils::setParentWindow(&fileDialog->dialog(), parent_window);
         fileDialog->setWindowTitle(title);
-        fileDialog->setModal(modalDialog);
+        fileDialog->setWindowModality(modalDialog ? Qt::WindowModal : Qt::NonModal);
         fileDialog->setFileMode(directory ? QFileDialog::Directory : (multipleFiles ? QFileDialog::ExistingFiles : QFileDialog::ExistingFile));
         if (!acceptLabel.isEmpty())
             fileDialog->setLabelText(QFileDialog::Accept, acceptLabel);
@@ -353,7 +353,7 @@ namespace LXQt
         auto fileDialog = FileDialogHelper::createFileDialogHelper();
         Utils::setParentWindow(&fileDialog->dialog(), parent_window);
         fileDialog->setWindowTitle(title);
-        fileDialog->setModal(modalDialog);
+        fileDialog->setWindowModality(modalDialog ? Qt::WindowModal : Qt::NonModal);
         fileDialog->setFileMode(QFileDialog::AnyFile);
         fileDialog->setAcceptMode(QFileDialog::AcceptSave);
         if (!acceptLabel.isEmpty())

--- a/src/filedialoghelper.h
+++ b/src/filedialoghelper.h
@@ -50,6 +50,7 @@ namespace LXQt
         inline void setFileMode(QFileDialog::FileMode mode) { options()->setFileMode(static_cast<QFileDialogOptions::FileMode>(mode)); }
         inline void setWindowTitle(const QString & title) { options()->setWindowTitle(title); }
         inline void setModal(bool modal) { dialog().setModal(modal); }
+        inline void setWindowModality(Qt::WindowModality modality) { dialog().setWindowModality(modality); }
         inline void setLabelText(QFileDialog::DialogLabel label, const QString &text) { options()->setLabelText(static_cast<QFileDialogOptions::DialogLabel>(label), text); };
         inline void setNameFilters(const QStringList &filters) { options()->setNameFilters(filters); }
         inline void setAcceptMode(QFileDialog::AcceptMode mode) { options()->setAcceptMode(static_cast<QFileDialogOptions::AcceptMode>(mode)); }


### PR DESCRIPTION
The file chooser dialog is `ApplicationModal` by default, causing that a dialog opened for one portal request blocks dialogs requested from other applications. Setting the dialog as `WindowModal` avoids this problem.
